### PR TITLE
Run default `cargo fmt`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,15 +37,25 @@ fn main() {
 /// 4. return an error
 fn find_must_gather_root(path: String) -> Option<PathBuf> {
     let orig = PathBuf::from(&path);
-    let vpath: PathBuf = [String::from(&path), String::from("version")].iter().collect();
-    let npath: PathBuf = [String::from(&path), String::from("namespaces")].iter().collect();
-    let csrpath : PathBuf = [String::from(&path), String::from("cluster-scoped-resources")].iter().collect();
+    let vpath: PathBuf = [String::from(&path), String::from("version")]
+        .iter()
+        .collect();
+    let npath: PathBuf = [String::from(&path), String::from("namespaces")]
+        .iter()
+        .collect();
+    let csrpath: PathBuf = [
+        String::from(&path),
+        String::from("cluster-scoped-resources"),
+    ]
+    .iter()
+    .collect();
 
     if vpath.is_file() || (npath.is_dir() && csrpath.is_dir()) {
-        return Some(orig)
+        return Some(orig);
     }
 
-    let directories: Vec<PathBuf> = fs::read_dir(orig).unwrap()
+    let directories: Vec<PathBuf> = fs::read_dir(orig)
+        .unwrap()
         .into_iter()
         .filter(|r| r.is_ok())
         .map(|r| r.unwrap().path())

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -7,7 +7,5 @@ pub struct IndexTemplate<'a> {
 }
 
 pub fn build_index_template(basename: &str) -> IndexTemplate {
-    IndexTemplate {
-        basename: basename,
-    }
+    IndexTemplate { basename: basename }
 }


### PR DESCRIPTION
Like Go, Rust has an opinionated out of the box code formatter
that most projects use.