### PR TITLE
Convert all name based resources to use uuid for css data

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -43,6 +43,8 @@ fn add_accordion_section(
         .attr("class=\"accordion\"")
         .attr(format!("id=\"{}-accordion\"", kind.to_lowercase()).as_str());
     for res in resources {
+        // use a UUID for the resource CSS id to avoid resource with similar names
+        let resuuid = Uuid::new_v4();
         let mut itemdiv = div.div().attr("class=\"accordion-item\"");
         let buttonclass = match (res.is_warning(), res.is_error()) {
             (true, _) => " bg-warning text-white",
@@ -52,20 +54,20 @@ fn add_accordion_section(
         itemdiv
             .h2()
             .attr("class=\"accordion-header\"")
-            .attr(format!("id=\"heading-{}\"", &res.safename()).as_str())
+            .attr(format!("id=\"heading-{}\"", &resuuid.hyphenated()).as_str())
             .button()
             .attr(format!("class=\"accordion-button collapsed p-2{}\"", buttonclass).as_str())
             .attr("type=\"button\"")
             .attr("data-bs-toggle=\"collapse\"")
-            .attr(format!("data-bs-target=\"#collapse-{}\"", &res.safename()).as_str())
+            .attr(format!("data-bs-target=\"#collapse-{}\"", &resuuid.hyphenated()).as_str())
             .attr("aria-exapnded=\"false\"")
-            .attr(format!("aria-controls=\"collapse-{}\"", &res.safename()).as_str())
+            .attr(format!("aria-controls=\"collapse-{}\"", &resuuid.hyphenated()).as_str())
             .write_str(&res.name())?;
         itemdiv
             .div()
-            .attr(format!("id=\"collapse-{}\"", &res.safename()).as_str())
+            .attr(format!("id=\"collapse-{}\"", &resuuid.hyphenated()).as_str())
             .attr("class=\"accordion-collapse collapse\"")
-            .attr(format!("aria-labelledby=\"heading-{}\"", &res.safename()).as_str())
+            .attr(format!("aria-labelledby=\"heading-{}\"", &resuuid.hyphenated()).as_str())
             .attr(format!("data-bs-parents=\"{}-accordion\"", kind.to_lowercase()).as_str())
             .div()
             .attr("class=\"accordion-body fs-6\"")

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -9,7 +9,6 @@ use yaml_rust::{Yaml, YamlLoader};
 #[derive(Debug, Clone)]
 pub struct Manifest {
     pub name: String,
-    pub safename: String,
     raw: String,
     yaml: Yaml,
 }
@@ -18,7 +17,6 @@ impl Manifest {
     pub fn new() -> Manifest {
         Manifest {
             name: String::new(),
-            safename: String::new(),
             raw: String::new(),
             yaml: Yaml::Null,
         }
@@ -46,13 +44,7 @@ impl Manifest {
                 Some(n) => String::from(n),
                 None => String::from("Unknown"),
             };
-            let safename = render_safename(name.as_str());
-            Ok(Manifest {
-                name,
-                raw,
-                safename,
-                yaml,
-            })
+            Ok(Manifest { name, raw, yaml })
         }
     }
 
@@ -96,10 +88,6 @@ impl Manifest {
 
         false
     }
-}
-
-pub fn render_safename(original: &str) -> String {
-    original.replace('.', "-").replace(':', "_").to_lowercase()
 }
 
 #[cfg(test)]
@@ -200,26 +188,5 @@ mod tests {
             "testdata/must-gather-valid/sample-openshift-release/cluster-scoped-resources/core/nodes/ip-10-0-0-1.control.plane.yaml"
         )).unwrap();
         assert_eq!(manifest.has_condition("FooBar"), false)
-    }
-
-    #[test]
-    fn test_render_safename_hyphen() {
-        let expected = String::from("ip-10-0-0-1-control-plane");
-        let observed = render_safename("ip-10-0-0-1.control.plane");
-        assert_eq!(observed, expected)
-    }
-
-    #[test]
-    fn test_render_safename_colon() {
-        let expected = String::from("ip-10-0-0-1_control_plane");
-        let observed = render_safename("ip-10-0-0-1:control:plane");
-        assert_eq!(observed, expected)
-    }
-
-    #[test]
-    fn test_render_safename_lowercase() {
-        let expected = String::from("ip-10-0-0-1_control_plane");
-        let observed = render_safename("IP-10-0-0-1_control_plane");
-        assert_eq!(observed, expected)
     }
 }

--- a/src/resources/certificatesigningrequest.rs
+++ b/src/resources/certificatesigningrequest.rs
@@ -25,10 +25,6 @@ impl Resource for CertificateSigningRequest {
         &self.manifest.as_raw()
     }
 
-    fn safename(&self) -> &String {
-        &self.manifest.safename
-    }
-
     fn is_error(&self) -> bool {
         self.denied || self.failed
     }

--- a/src/resources/clusterautoscaler.rs
+++ b/src/resources/clusterautoscaler.rs
@@ -21,8 +21,4 @@ impl Resource for ClusterAutoscaler {
     fn raw(&self) -> &String {
         &self.manifest.as_raw()
     }
-
-    fn safename(&self) -> &String {
-        &self.manifest.safename
-    }
 }

--- a/src/resources/machine.rs
+++ b/src/resources/machine.rs
@@ -27,10 +27,6 @@ impl Resource for Machine {
     fn raw(&self) -> &String {
         &self.manifest.as_raw()
     }
-
-    fn safename(&self) -> &String {
-        &self.manifest.safename
-    }
 }
 
 fn is_running_phase(manifest: &Manifest) -> bool {

--- a/src/resources/machineautoscaler.rs
+++ b/src/resources/machineautoscaler.rs
@@ -21,8 +21,4 @@ impl Resource for MachineAutoscaler {
     fn raw(&self) -> &String {
         &self.manifest.as_raw()
     }
-
-    fn safename(&self) -> &String {
-        &self.manifest.safename
-    }
 }

--- a/src/resources/machineset.rs
+++ b/src/resources/machineset.rs
@@ -43,10 +43,6 @@ impl Resource for MachineSet {
     fn raw(&self) -> &String {
         &self.manifest.as_raw()
     }
-
-    fn safename(&self) -> &String {
-        &self.manifest.safename
-    }
 }
 
 fn has_autoscaling_annotations(manifest: &Manifest) -> bool {

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -23,7 +23,6 @@ pub trait Resource {
     fn from(manifest: Manifest) -> Self;
     fn name(&self) -> &String;
     fn raw(&self) -> &String;
-    fn safename(&self) -> &String;
 
     fn is_error(&self) -> bool {
         false

--- a/src/resources/node.rs
+++ b/src/resources/node.rs
@@ -27,8 +27,4 @@ impl Resource for Node {
     fn raw(&self) -> &String {
         &self.manifest.as_raw()
     }
-
-    fn safename(&self) -> &String {
-        &self.manifest.safename
-    }
 }

--- a/src/resources/pod.rs
+++ b/src/resources/pod.rs
@@ -1,7 +1,6 @@
 // Copyright (C) 2022 Red Hat, Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::manifest::render_safename;
 use crate::prelude::*;
 use crate::resources::Resource;
 
@@ -40,10 +39,6 @@ impl Resource for Pod {
     fn raw(&self) -> &String {
         &self.manifest.as_raw()
     }
-
-    fn safename(&self) -> &String {
-        &self.manifest.safename
-    }
 }
 
 /// Holds the name and raw log files of a container within a pod.
@@ -51,10 +46,4 @@ impl Resource for Pod {
 pub struct Container {
     pub name: String,
     pub current_log: String,
-}
-
-impl Container {
-    pub fn safename(&self) -> String {
-        render_safename(&self.name.as_str())
-    }
 }


### PR DESCRIPTION
this change updates the way accordion data is created in the html module by replacing the previous safename behavior with uuids for all the css related identifiers. this allows each accordion to be opened independently without affecting others.

also, as part of the cleanup it removes the old safename functions and tests.

closes #13 