### PR TITLE
Implement tar extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,15 +89,30 @@ version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",
+ "flate2",
  "futures-channel",
  "futures-util",
  "html-builder",
+ "infer",
  "notify",
+ "tar",
+ "tempdir",
  "tokio",
  "tokio-stream",
  "uuid",
  "warp",
  "yaml-rust",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -146,6 +167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +226,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +269,12 @@ checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -472,6 +518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f178e61cdbfe084aa75a2f4f7a25a5bb09701a47ae1753608f194b15783c937a"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "inotify"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,7 +736,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error",
- "rand",
+ "rand 0.8.5",
  "safemem",
  "tempfile",
  "twoway",
@@ -864,13 +928,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -880,8 +957,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -890,6 +982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1042,6 +1143,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -1222,7 +1344,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha-1 0.9.8",
  "thiserror",
  "url",
@@ -1299,7 +1421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom",
- "rand",
+ "rand 0.8.5",
  "uuid-macro-internal",
 ]
 
@@ -1471,6 +1593,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ clap = { version = "3.0.14", features = ["derive"] }
 anyhow = "1.0.53"
 html-builder = "0.3"
 yaml-rust = "0.4.5"
+tar = "0.4.38"
+tempdir = "0.3.7"
+flate2 = "1.0.24"
+infer = "0.9.0"
 
 [dependencies.uuid]
 version = "1.0.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,15 +12,26 @@ mod prelude {
     pub use crate::mustgather::*;
     pub use anyhow::{anyhow, Result};
 }
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+};
+
 use crate::prelude::*;
 
 use clap::Parser;
+use flate2::read::GzDecoder;
+use tar::Archive;
+use tempdir::TempDir;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    // The path to the must-gather.
+    /// The path to the must-gather.
     path: String,
+    /// Open a must-gather archive in tar format
+    #[clap(long)]
+    tar: bool,
 }
 
 fn main() -> Result<()> {
@@ -35,10 +46,51 @@ fn main() -> Result<()> {
         std::fs::create_dir_all("target/html")?;
         std::fs::write("target/html/index.html", index.render())?;
     } else {
-        let mg = MustGather::from(cli.path)?;
+        let mg;
+        let tmp_dir;
+        if cli.tar {
+            tmp_dir = match extract_tar(&cli.path) {
+                Ok(dir) => dir,
+                Err(error) => {
+                    eprintln!("Could not extract tar file: {}", cli.path);
+                    return Err(error);
+                }
+            };
+            mg = MustGather::from(tmp_dir.path().to_str().unwrap().to_owned())?;
+        } else {
+            mg = MustGather::from(cli.path)?;
+        }
 
         let index = Html::from(mg)?;
         println!("{}", index.render());
     }
     Ok(())
+}
+
+// extract_tar extracts tar or tar.gz file into a temporary directory.
+// The temporary directory has lifetime of the returned TempDir object.
+fn extract_tar(path: &str) -> Result<TempDir> {
+    let mut tar_file = File::open(path)?;
+
+    // Infer file type from magic number
+    let mut buf = [0; 512];
+    tar_file.read_exact(&mut buf)?;
+    tar_file.seek(SeekFrom::Start(0))?;
+    let kind = match infer::get(&buf) {
+        Some(kind) => kind,
+        None => Err(anyhow!("Unknown file type"))?,
+    };
+
+    // If the file is gzipped, wrap it in a GzDecoder.
+    let reader: Box<dyn Read> = match kind.mime_type() {
+        "application/gzip" => Box::new(GzDecoder::new(tar_file)),
+        "application/x-tar" => Box::new(tar_file),
+        _ => Err(anyhow!("Unsupported file type"))?,
+    };
+
+    // Unpack the tar file into a temporary directory.
+    let mut archive = Archive::new(reader);
+    let tmp_dir = TempDir::new("camgi-must-gather")?;
+    archive.unpack(tmp_dir.path())?;
+    Ok(tmp_dir)
 }


### PR DESCRIPTION
Adds new `--tar` option that extracts must gather file in `tar` or `tar.gz` format into temporary system directory

File type is inferred from magic number. This is important because the must_gather.tar in OpenShift CI is actually tar.gz.