### PR TITLE
update html title to prepend camgi-

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -181,7 +181,8 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
 
 fn add_head(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     let mut head = parent.head();
-    head.title().write_str(mustgather.title.as_str())?;
+    head.title()
+        .write_str(format!("camgi-{}", mustgather.title).as_str())?;
     head.meta().attr("charset='utf-8'");
     head.link()
         .attr("href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css\"")


### PR DESCRIPTION
This is being added to make visibility better when embedding pages, but also just to make it more clear when the directory name might be more ambiguous.

closes #25 