### PR TITLE
mustgather: Use clearer+more efficient loop pattern

### DIFF
--- a/src/mustgather.rs
+++ b/src/mustgather.rs
@@ -240,14 +240,9 @@ fn get_pod(pod_dir: &PathBuf) -> Option<Pod> {
     }
 
     if let Ok(container_dirs) = fs::read_dir(&pod_dir) {
-        let container_dirs: Vec<PathBuf> = container_dirs
-            .into_iter()
-            .filter(|r| r.is_ok())
-            .map(|r| r.unwrap().path())
-            .filter(|r| r.is_dir())
-            .collect();
         // loop through container dirs
         for container_dir in container_dirs {
+            let container_dir = container_dir.ok()?.path();
             //   build path to log file
             let container_name = match container_dir.file_name() {
                 Some(basename) => basename.to_str().unwrap_or("not_found"),


### PR DESCRIPTION
When to use combinators in Rust involved a lot of learning over time for me.  Sometimes, combinators are a lot clearer; other times they aren't.

In this case, I think it's much clearer to directly perform operations inside the loop.  This is also more efficient because we aren't calling `.collect()` to create an intermediate vector (though we could have just dropped that call at the end of the
 combinator chain).

Also of note instead of `is_ok()` + `unwrap()` we can just call `ok()`.

That said, I personally think we should be making use of `Result<>` here to propagate errors instead of ignoring them.