### PR TITLE
Drop various allocations when manipulating paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,7 @@ fn main() -> Result<()> {
 
     if cli.path == "demo" {
         // Special case to render a demo report
-        let mg =
-            MustGather::from("testdata/must-gather-valid/sample-openshift-release/".to_string())?;
+        let mg = MustGather::from("testdata/must-gather-valid/sample-openshift-release/")?;
         let index = Html::from(mg)?;
 
         std::fs::create_dir_all("target/html")?;


### PR DESCRIPTION
Use a borrowed reference `&Path` to a path instead of passing down an owned String.  There were some unnecessary `String::from()` allocations when constructing sub-paths; also because we only are looking for one child, we can just use `PathBuf::join`.