### PR TITLE
ci: Use `devel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [devel]
   pull_request:
-    branches: [main]
+    branches: [devel]
 
 permissions:
   contents: read


### PR DESCRIPTION
For some reason this repository uses `devel`, not `main` or `master`.