### PR TITLE
add ccm and ccmo tabs

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -122,6 +122,7 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     // nav entries for component sections
     add_navlist_entry(&mut navlist, "Machine API", &mustgather.mapipods)?;
     add_navlist_entry(&mut navlist, "Machine Config", &mustgather.mcopods)?;
+    add_navlist_entry(&mut navlist, "CCMs", &mustgather.ccmpods)?;
 
     // nav entries for resources
     add_navlist_entry(&mut navlist, "Autoscaling", &mustgather.clusterautoscalers)?;
@@ -158,6 +159,7 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     add_summary_data(&mut body, &mustgather)?;
     add_machine_api_data(&mut body, &mustgather)?;
     add_machine_config_data(&mut body, &mustgather)?;
+    add_ccms_data(&mut body, &mustgather)?;
     add_autoscaling_data(&mut body, &mustgather)?;
     add_resource_data(&mut body, "MachineSets", &mustgather.machinesets)?;
     add_resource_data(&mut body, "Machines", &mustgather.machines)?;
@@ -175,6 +177,16 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
         .attr("src=\"https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js\"");
     body.script()
         .write_str(include_str!("files/index_script.js"))?;
+
+    Ok(())
+}
+
+fn add_ccms_data(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
+    let mut data = parent.data().attr("id=\"ccms-data\"");
+
+    data.h1().write_str("Cloud Controller Manager Pods")?;
+
+    add_pod_accordions(&mut data, &mustgather.ccmpods)?;
 
     Ok(())
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -186,7 +186,8 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
 fn add_ccmo_data(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     let mut data = parent.data().attr("id=\"ccm_operator-data\"");
 
-    data.h1().write_str("Cloud Controller Manager Operator Pods")?;
+    data.h1()
+        .write_str("Cloud Controller Manager Operator Pods")?;
 
     add_pod_accordions(&mut data, &mustgather.ccmopods)?;
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -122,6 +122,7 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     // nav entries for component sections
     add_navlist_entry(&mut navlist, "Machine API", &mustgather.mapipods)?;
     add_navlist_entry(&mut navlist, "Machine Config", &mustgather.mcopods)?;
+    add_navlist_entry(&mut navlist, "CCM Operator", &mustgather.ccmopods)?;
     add_navlist_entry(&mut navlist, "CCMs", &mustgather.ccmpods)?;
 
     // nav entries for resources
@@ -159,6 +160,7 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     add_summary_data(&mut body, &mustgather)?;
     add_machine_api_data(&mut body, &mustgather)?;
     add_machine_config_data(&mut body, &mustgather)?;
+    add_ccmo_data(&mut body, &mustgather)?;
     add_ccms_data(&mut body, &mustgather)?;
     add_autoscaling_data(&mut body, &mustgather)?;
     add_resource_data(&mut body, "MachineSets", &mustgather.machinesets)?;
@@ -177,6 +179,16 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
         .attr("src=\"https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js\"");
     body.script()
         .write_str(include_str!("files/index_script.js"))?;
+
+    Ok(())
+}
+
+fn add_ccmo_data(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
+    let mut data = parent.data().attr("id=\"ccm_operator-data\"");
+
+    data.h1().write_str("Cloud Controller Manager Operator Pods")?;
+
+    add_pod_accordions(&mut data, &mustgather.ccmopods)?;
 
     Ok(())
 }

--- a/src/mustgather.rs
+++ b/src/mustgather.rs
@@ -107,8 +107,13 @@ impl MustGather {
             build_manifest_path(&path, "", "openshift-machine-config-operator", "pods", "");
         let mcopods = get_pods(&manifestpath);
 
-        let manifestpath =
-            build_manifest_path(&path, "", "openshift-cloud-controller-manager-operator", "pods", "");
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cloud-controller-manager-operator",
+            "pods",
+            "",
+        );
         let ccmopods = get_pods(&manifestpath);
 
         let manifestpath =

--- a/src/mustgather.rs
+++ b/src/mustgather.rs
@@ -19,6 +19,7 @@ pub struct MustGather {
     pub controlplanemachinesets: Vec<ControlPlaneMachineSet>,
     pub mapipods: Vec<Pod>,
     pub mcopods: Vec<Pod>,
+    pub ccmopods: Vec<Pod>,
     pub ccmpods: Vec<Pod>,
 }
 
@@ -107,6 +108,10 @@ impl MustGather {
         let mcopods = get_pods(&manifestpath);
 
         let manifestpath =
+            build_manifest_path(&path, "", "openshift-cloud-controller-manager-operator", "pods", "");
+        let ccmopods = get_pods(&manifestpath);
+
+        let manifestpath =
             build_manifest_path(&path, "", "openshift-cloud-controller-manager", "pods", "");
         let ccmpods = get_pods(&manifestpath);
 
@@ -123,6 +128,7 @@ impl MustGather {
             controlplanemachinesets,
             mapipods,
             mcopods,
+            ccmopods,
             ccmpods,
         })
     }

--- a/src/mustgather.rs
+++ b/src/mustgather.rs
@@ -19,6 +19,7 @@ pub struct MustGather {
     pub controlplanemachinesets: Vec<ControlPlaneMachineSet>,
     pub mapipods: Vec<Pod>,
     pub mcopods: Vec<Pod>,
+    pub ccmpods: Vec<Pod>,
 }
 
 impl MustGather {
@@ -105,6 +106,10 @@ impl MustGather {
             build_manifest_path(&path, "", "openshift-machine-config-operator", "pods", "");
         let mcopods = get_pods(&manifestpath);
 
+        let manifestpath =
+            build_manifest_path(&path, "", "openshift-cloud-controller-manager", "pods", "");
+        let ccmpods = get_pods(&manifestpath);
+
         Ok(MustGather {
             title,
             version,
@@ -118,6 +123,7 @@ impl MustGather {
             controlplanemachinesets,
             mapipods,
             mcopods,
+            ccmpods,
         })
     }
 }

--- a/src/resources/machine.rs
+++ b/src/resources/machine.rs
@@ -43,7 +43,7 @@ fn is_running_phase(manifest: &Manifest) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ::std::path::PathBuf;
+    use std::path::PathBuf;
 
     #[test]
     fn test_machine_is_running_phase_true() {

--- a/src/resources/machineset.rs
+++ b/src/resources/machineset.rs
@@ -73,7 +73,7 @@ fn status_replicas(manifest: &Manifest) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ::std::path::PathBuf;
+    use std::path::PathBuf;
 
     #[test]
     fn test_machineset_has_autoscaling_annotations_true() {


### PR DESCRIPTION
this change set brings in 2 news navigation tabs, one for the cloud controller manager operator, and one for the cloud controller managers.

closes: #31 