### PR TITLE
add clusteroperators to output

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -47,7 +47,7 @@ fn add_accordion_section(
         let resuuid = Uuid::new_v4();
         let mut itemdiv = div.div().attr("class=\"accordion-item\"");
         let buttonclass = match (res.is_warning(), res.is_error()) {
-            (true, _) => " bg-warning text-white",
+            (true, false) => " bg-warning text-white",
             (_, true) => " bg-danger text-white",
             _ => "",
         };
@@ -119,6 +119,13 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
         .attr("class=\"list-group-item list-group-item-action\"")
         .write_str("Summary")?;
 
+    // cluster info sections
+    add_navlist_entry(
+        &mut navlist,
+        "Cluster Operators",
+        &mustgather.clusteroperators,
+    )?;
+
     // nav entries for component sections
     add_navlist_entry(&mut navlist, "Machine API", &mustgather.mapipods)?;
     add_navlist_entry(&mut navlist, "Machine Config", &mustgather.mcopods)?;
@@ -158,6 +165,7 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     // data sections are used by the nav list and vue app to change the content
     // in the div#main-content element.
     add_summary_data(&mut body, &mustgather)?;
+    add_resource_data(&mut body, "Cluster Operators", &mustgather.clusteroperators)?;
     add_machine_api_data(&mut body, &mustgather)?;
     add_machine_config_data(&mut body, &mustgather)?;
     add_ccmo_data(&mut body, &mustgather)?;
@@ -282,7 +290,7 @@ fn add_pod_accordions(parent: &mut Node, pods: &Vec<Pod>) -> Result<()> {
 
         let mut itemdiv = div.div().attr("class=\"accordion-item\"");
         let buttonclass = match (pod.is_warning(), pod.is_error()) {
-            (true, _) => " bg-warning text-white",
+            (true, false) => " bg-warning text-white",
             (_, true) => " bg-danger text-white",
             _ => "",
         };

--- a/src/mustgather.rs
+++ b/src/mustgather.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 pub struct MustGather {
     pub title: String,
     pub version: String,
+    pub clusteroperators: Vec<ClusterOperator>,
     pub machines: Vec<Machine>,
     pub machinesets: Vec<MachineSet>,
     pub nodes: Vec<Node>,
@@ -33,6 +34,10 @@ impl MustGather {
         let path = find_must_gather_root(path)?;
         let title = String::from(path.file_name().unwrap().to_str().unwrap());
         let version = get_cluster_version(&path);
+
+        let manifestpath =
+            build_manifest_path(&path, "", "", "clusteroperators", "config.openshift.io");
+        let clusteroperators = get_resources::<ClusterOperator>(&manifestpath);
 
         let manifestpath = build_manifest_path(
             &path,
@@ -123,6 +128,7 @@ impl MustGather {
         Ok(MustGather {
             title,
             version,
+            clusteroperators,
             machines,
             machinesets,
             nodes,

--- a/src/resources/clusteroperator.rs
+++ b/src/resources/clusteroperator.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct ClusterOperator {
+    manifest: Manifest,
+    available: bool,
+    degraded: bool,
+    upgradeable: bool,
+    has_upgradeable: bool,
+}
+
+impl Resource for ClusterOperator {
+    fn from(manifest: Manifest) -> ClusterOperator {
+        let available = manifest.has_condition_status("Available", "True");
+        let degraded = manifest.has_condition_status("Degraded", "True");
+        let upgradeable = manifest.has_condition_status("Upgradeable", "True");
+        let has_upgradeable = manifest.has_condition("Upgradeable");
+        ClusterOperator {
+            manifest,
+            available,
+            degraded,
+            upgradeable,
+            has_upgradeable,
+        }
+    }
+
+    fn is_error(&self) -> bool {
+        !self.available || self.degraded
+    }
+
+    fn is_warning(&self) -> bool {
+        !self.upgradeable && self.has_upgradeable
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        &self.manifest.as_raw()
+    }
+}

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -4,6 +4,7 @@
 pub mod baremetalhost;
 pub mod certificatesigningrequest;
 pub mod clusterautoscaler;
+pub mod clusteroperator;
 pub mod controlplanemachineset;
 pub mod machine;
 pub mod machineautoscaler;
@@ -14,6 +15,7 @@ pub mod pod;
 pub use crate::resources::baremetalhost::BareMetalHost;
 pub use crate::resources::certificatesigningrequest::CertificateSigningRequest;
 pub use crate::resources::clusterautoscaler::ClusterAutoscaler;
+pub use crate::resources::clusteroperator::ClusterOperator;
 pub use crate::resources::controlplanemachineset::ControlPlaneMachineSet;
 pub use crate::resources::machine::Machine;
 pub use crate::resources::machineautoscaler::MachineAutoscaler;


### PR DESCRIPTION
this change brings in the clusteroperator type to the output, it will add an error status to an record which has the available condition set to false or the degraded condition set to true. further, it will add the warning status to any record which contains the upgradeable condition set to false.

this change also fixes an issue with warnings overriding errors in the generated accordion output.

closes #32 