### PR TITLE
fix error in managed fields removal

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -64,12 +64,14 @@ impl Manifest {
                     .clone();
                 ycopy.remove(&Yaml::String(String::from("spec")));
                 ycopy.insert(Yaml::String(String::from("spec")), Yaml::Hash(spec));
-                let status = ycopy[&Yaml::String(String::from("status"))]
-                    .as_hash()
-                    .unwrap_or(&Hash::new())
-                    .clone();
-                ycopy.remove(&Yaml::String(String::from("status")));
-                ycopy.insert(Yaml::String(String::from("status")), Yaml::Hash(status));
+                if yaml["status"].as_hash().is_some() {
+                    let status = ycopy[&Yaml::String(String::from("status"))]
+                        .as_hash()
+                        .unwrap_or(&Hash::new())
+                        .clone();
+                    ycopy.remove(&Yaml::String(String::from("status")));
+                    ycopy.insert(Yaml::String(String::from("status")), Yaml::Hash(status));
+                }
 
                 yaml = Yaml::Hash(ycopy);
                 let mut out_str = String::new();

--- a/src/mustgather.rs
+++ b/src/mustgather.rs
@@ -474,7 +474,7 @@ mod tests {
     fn test_get_resources_success() {
         let path = PathBuf::from("testdata/must-gather-valid/sample-openshift-release");
         let manifestpath = build_manifest_path(&path, "", "", "nodes", "core");
-        assert_eq!(get_resources::<Node>(&manifestpath).len(), 3)
+        assert_eq!(get_resources::<Node>(&manifestpath).len(), 4)
     }
 
     #[test]

--- a/testdata/must-gather-valid/sample-openshift-release/cluster-scoped-resources/core/nodes/ip-10-0-0-3.worker.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/cluster-scoped-resources/core/nodes/ip-10-0-0-3.worker.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    machine.openshift.io/machine: openshift-machine-api/control-plane1
+    machineconfiguration.openshift.io/controlPlaneTopology: HighlyAvailable
+    machineconfiguration.openshift.io/currentConfig: rendered-master-0
+    machineconfiguration.openshift.io/desiredConfig: rendered-master-0
+    machineconfiguration.openshift.io/reason: ""
+    machineconfiguration.openshift.io/state: Done
+    nfd.node.kubernetes.io/master.version: "1.16"
+    volumes.kubernetes.io/controller-managed-attach-detach: "true"
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/instance-type: xlarge
+    beta.kubernetes.io/os: linux
+    failure-domain.beta.kubernetes.io/region: region-1
+    failure-domain.beta.kubernetes.io/zone: zone-1
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: ip-10-0-0-1.control.plane
+    kubernetes.io/os: linux
+    node-role.kubernetes.io/master: ""
+    node.kubernetes.io/instance-type: xlarge
+    node.openshift.io/os_id: rhcos
+    topology.kubernetes.io/region: region-1
+    topology.kubernetes.io/zone: zone-1
+  name: ip-10-0-0-3.worker
+  resourceVersion: "89485"
+  uid: 00000000-0000-0000-0000-000000000000
+  managedFields:
+  - apiVersion: machine.openshift.io/v1beta1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:machine.openshift.io/cluster-api-cluster: {}
+          f:machine.openshift.io/cluster-api-machine-role: {}
+          f:machine.openshift.io/cluster-api-machine-type: {}
+          f:spec:
+            .: {}
+            f:lifecycleHooks: {}
+            f:metadata: {}
+            f:providerSpec:
+              .: {}
+              f:value:
+                .: {}
+                f:ami:
+                  .: {}
+                  f:id: {}
+                  f:apiVersion: {}
+                  f:blockDevices: {}
+                  f:credentialsSecret:
+                    .: {}
+                    f:name: {}
+                    f:deviceIndex: {}
+                    f:iamInstanceProfile:
+                      .: {}
+                      f:id: {}
+                      f:instanceType: {}
+                      f:kind: {}
+                      f:loadBalancers: {}
+                      f:metadata:
+                        .: {}
+                        f:creationTimestamp: {}
+                        f:placement:
+                          .: {}
+                          f:availabilityZone: {}
+                          f:region: {}
+                          f:securityGroups: {}
+                          f:subnet:
+                            .: {}
+                            f:filters: {}
+                            f:tags: {}
+                            f:userDataSecret:
+                              .: {}
+                              f:name: {}
+spec:
+  providerID: fake://ip-10-0-0-3.worker
+  taints:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master


### PR DESCRIPTION
if a record did not have a "status" field, the removal of the managed fields would panic. this change ensures that we don't try to remove status unless it exists. also adds a test case to confirm behavior.

fixes #52 