### PR TITLE
aws: add support to display Cluster API resource

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -158,6 +158,7 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     add_navlist_entry(&mut navlist, "BareMetalHosts", &mustgather.baremetalhosts)?;
     add_navlist_entry(&mut navlist, "Nodes", &mustgather.nodes)?;
     add_navlist_entry(&mut navlist, "CSRs", &mustgather.csrs)?;
+    add_capi_navlist_entry(&mut navlist, mustgather)?;
 
     // github link should go last
     navlist
@@ -207,6 +208,9 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
     add_resource_data(&mut body, "CPMSs", &mustgather.controlplanemachinesets)?;
     add_resource_data(&mut body, "CSRs", &mustgather.csrs)?;
 
+    // Cluster API data section
+    add_cluster_api_data(&mut body, mustgather)?;
+
     // scripts
     body.script()
         .attr("src=\"https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js\"")
@@ -216,6 +220,52 @@ fn add_body(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
         .attr("src=\"https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js\"");
     body.script()
         .write_str(include_str!("files/index_script.js"))?;
+
+    Ok(())
+}
+
+fn add_cluster_api_data(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
+    let mut data = parent.data().attr("id=\"cluster_api-data\"");
+
+    data.h1().write_str("Cluster API Pods")?;
+    add_pod_accordions(&mut data, &mustgather.capipods)?;
+
+    data.div().attr("class=\"p-2\"");
+    add_accordion_section(&mut data, "Clusters", &mustgather.capiclusters)?;
+
+    if !mustgather.awsclusters.is_empty() {
+        data.div().attr("class=\"p-2\"");
+        add_accordion_section(&mut data, "AWSClusters", &mustgather.awsclusters)?;
+    }
+
+    data.div().attr("class=\"p-2\"");
+    add_accordion_section(&mut data, "MachineSets", &mustgather.capimachinesets)?;
+
+    data.div().attr("class=\"p-2\"");
+    add_accordion_section(
+        &mut data,
+        "MachineDeployments",
+        &mustgather.capimachinedeployments,
+    )?;
+
+    data.div().attr("class=\"p-2\"");
+    add_accordion_section(&mut data, "Machines", &mustgather.capimachines)?;
+
+    if !mustgather.awsmachines.is_empty() {
+        data.div().attr("class=\"p-2\"");
+        add_accordion_section(&mut data, "AWSMachines", &mustgather.awsmachines)?;
+    }
+
+    if !mustgather.awsmachinetemplates.is_empty() {
+        data.div().attr("class=\"p-2\"");
+        add_accordion_section(
+            &mut data,
+            "AWSMachineTemplates",
+            &mustgather.awsmachinetemplates,
+        )?;
+    }
+
+    data.div().attr("class=\"p-2\"");
 
     Ok(())
 }
@@ -273,6 +323,118 @@ fn add_machine_config_pods_data(parent: &mut Node, mustgather: &MustGather) -> R
 
     add_pod_accordions(&mut data, &mustgather.mcopods)?;
 
+    Ok(())
+}
+
+fn add_capi_navlist_entry(parent: &mut Node, mustgather: &MustGather) -> Result<()> {
+    let has_capi = !mustgather.capipods.is_empty()
+        || !mustgather.capiclusters.is_empty()
+        || !mustgather.capimachinesets.is_empty()
+        || !mustgather.capimachinedeployments.is_empty()
+        || !mustgather.capimachines.is_empty()
+        || !mustgather.awsclusters.is_empty()
+        || !mustgather.awsmachines.is_empty()
+        || !mustgather.awsmachinetemplates.is_empty();
+    let mut aclass = "class=\"list-group-item list-group-item-action\"";
+    let mut clickattr = String::from("v-on:click=\"changeContent('cluster_api')\"");
+    if !has_capi {
+        aclass = "class=\"list-group-item list-group-item-action disabled\"";
+        clickattr = String::new();
+    }
+    let mut button = parent.button().attr(aclass).attr(clickattr.as_str());
+    button.write_str("Cluster API")?;
+
+    if has_capi {
+        let errors = mustgather.capipods.iter().filter(|r| r.is_error()).count()
+            + mustgather
+                .capiclusters
+                .iter()
+                .filter(|r| r.is_error())
+                .count()
+            + mustgather
+                .capimachinesets
+                .iter()
+                .filter(|r| r.is_error())
+                .count()
+            + mustgather
+                .capimachinedeployments
+                .iter()
+                .filter(|r| r.is_error())
+                .count()
+            + mustgather
+                .capimachines
+                .iter()
+                .filter(|r| r.is_error())
+                .count()
+            + mustgather
+                .awsclusters
+                .iter()
+                .filter(|r| r.is_error())
+                .count()
+            + mustgather
+                .awsmachines
+                .iter()
+                .filter(|r| r.is_error())
+                .count()
+            + mustgather
+                .awsmachinetemplates
+                .iter()
+                .filter(|r| r.is_error())
+                .count();
+        if errors > 0 {
+            button
+                .span()
+                .attr("class=\"badge bg-danger float-right\"")
+                .write_str(format!("{}", errors).as_str())?;
+        }
+
+        let warnings = mustgather
+            .capipods
+            .iter()
+            .filter(|r| r.is_warning())
+            .count()
+            + mustgather
+                .capiclusters
+                .iter()
+                .filter(|r| r.is_warning())
+                .count()
+            + mustgather
+                .capimachinesets
+                .iter()
+                .filter(|r| r.is_warning())
+                .count()
+            + mustgather
+                .capimachinedeployments
+                .iter()
+                .filter(|r| r.is_warning())
+                .count()
+            + mustgather
+                .capimachines
+                .iter()
+                .filter(|r| r.is_warning())
+                .count()
+            + mustgather
+                .awsclusters
+                .iter()
+                .filter(|r| r.is_warning())
+                .count()
+            + mustgather
+                .awsmachines
+                .iter()
+                .filter(|r| r.is_warning())
+                .count()
+            + mustgather
+                .awsmachinetemplates
+                .iter()
+                .filter(|r| r.is_warning())
+                .count();
+        if warnings > 0 {
+            button
+                .span()
+                .attr("class=\"badge bg-warning float-right\"")
+                .write_str(format!("{}", warnings).as_str())?;
+        }
+    }
     Ok(())
 }
 

--- a/src/mustgather.rs
+++ b/src/mustgather.rs
@@ -25,10 +25,18 @@ pub struct MustGather {
     pub machineautoscalers: Vec<MachineAutoscaler>,
     pub baremetalhosts: Vec<BareMetalHost>,
     pub controlplanemachinesets: Vec<ControlPlaneMachineSet>,
+    pub capiclusters: Vec<CAPICluster>,
+    pub capimachines: Vec<CAPIMachine>,
+    pub capimachinesets: Vec<CAPIMachineSet>,
+    pub capimachinedeployments: Vec<CAPIMachineDeployment>,
+    pub awsclusters: Vec<AWSCluster>,
+    pub awsmachines: Vec<AWSMachine>,
+    pub awsmachinetemplates: Vec<AWSMachineTemplate>,
     pub mapipods: Vec<Pod>,
     pub mcopods: Vec<Pod>,
     pub ccmopods: Vec<Pod>,
     pub ccmpods: Vec<Pod>,
+    pub capipods: Vec<Pod>,
 }
 
 impl MustGather {
@@ -140,6 +148,69 @@ impl MustGather {
         );
         let controlplanemachinesets = get_resources::<ControlPlaneMachineSet>(&manifestpath);
 
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cluster-api",
+            "clusters",
+            "cluster.x-k8s.io",
+        );
+        let capiclusters = get_resources::<CAPICluster>(&manifestpath);
+
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cluster-api",
+            "machines",
+            "cluster.x-k8s.io",
+        );
+        let capimachines = get_resources::<CAPIMachine>(&manifestpath);
+
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cluster-api",
+            "machinesets",
+            "cluster.x-k8s.io",
+        );
+        let capimachinesets = get_resources::<CAPIMachineSet>(&manifestpath);
+
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cluster-api",
+            "machinedeployments",
+            "cluster.x-k8s.io",
+        );
+        let capimachinedeployments = get_resources::<CAPIMachineDeployment>(&manifestpath);
+
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cluster-api",
+            "awsclusters",
+            "infrastructure.cluster.x-k8s.io",
+        );
+        let awsclusters = get_resources::<AWSCluster>(&manifestpath);
+
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cluster-api",
+            "awsmachines",
+            "infrastructure.cluster.x-k8s.io",
+        );
+        let awsmachines = get_resources::<AWSMachine>(&manifestpath);
+
+        let manifestpath = build_manifest_path(
+            &path,
+            "",
+            "openshift-cluster-api",
+            "awsmachinetemplates",
+            "infrastructure.cluster.x-k8s.io",
+        );
+        let awsmachinetemplates = get_resources::<AWSMachineTemplate>(&manifestpath);
+
         let manifestpath = build_manifest_path(&path, "", "openshift-machine-api", "pods", "");
         let mapipods = get_pods(&manifestpath);
 
@@ -160,6 +231,9 @@ impl MustGather {
             build_manifest_path(&path, "", "openshift-cloud-controller-manager", "pods", "");
         let ccmpods = get_pods(&manifestpath);
 
+        let manifestpath = build_manifest_path(&path, "", "openshift-cluster-api", "pods", "");
+        let capipods = get_pods(&manifestpath);
+
         Ok(MustGather {
             title,
             version,
@@ -176,10 +250,18 @@ impl MustGather {
             machineautoscalers,
             baremetalhosts,
             controlplanemachinesets,
+            capiclusters,
+            capimachines,
+            capimachinesets,
+            capimachinedeployments,
+            awsclusters,
+            awsmachines,
+            awsmachinetemplates,
             mapipods,
             mcopods,
             ccmopods,
             ccmpods,
+            capipods,
         })
     }
 }

--- a/src/resources/awscluster.rs
+++ b/src/resources/awscluster.rs
@@ -1,0 +1,56 @@
+// Copyright (C) 2022 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct AWSCluster {
+    manifest: Manifest,
+    ready: bool,
+}
+
+impl Resource for AWSCluster {
+    fn from(manifest: Manifest) -> AWSCluster {
+        let ready = manifest.as_yaml()["status"]["ready"]
+            .as_bool()
+            .unwrap_or(false);
+        AWSCluster { manifest, ready }
+    }
+
+    fn is_error(&self) -> bool {
+        !self.ready
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        self.manifest.as_raw()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_awscluster_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsclusters/testdata.yaml",
+        )).unwrap();
+        let cluster = <AWSCluster as Resource>::from(manifest);
+        assert_eq!(cluster.is_error(), false)
+    }
+
+    #[test]
+    fn test_awscluster_not_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsclusters/testdata-not-ready.yaml",
+        )).unwrap();
+        let cluster = <AWSCluster as Resource>::from(manifest);
+        assert_eq!(cluster.is_error(), true)
+    }
+}

--- a/src/resources/awsmachine.rs
+++ b/src/resources/awsmachine.rs
@@ -1,0 +1,56 @@
+// Copyright (C) 2022 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct AWSMachine {
+    manifest: Manifest,
+    ready: bool,
+}
+
+impl Resource for AWSMachine {
+    fn from(manifest: Manifest) -> AWSMachine {
+        let ready = manifest.as_yaml()["status"]["ready"]
+            .as_bool()
+            .unwrap_or(false);
+        AWSMachine { manifest, ready }
+    }
+
+    fn is_error(&self) -> bool {
+        !self.ready
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        self.manifest.as_raw()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_awsmachine_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-0.yaml",
+        )).unwrap();
+        let machine = <AWSMachine as Resource>::from(manifest);
+        assert_eq!(machine.is_error(), false)
+    }
+
+    #[test]
+    fn test_awsmachine_not_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-not-ready.yaml",
+        )).unwrap();
+        let machine = <AWSMachine as Resource>::from(manifest);
+        assert_eq!(machine.is_error(), true)
+    }
+}

--- a/src/resources/awsmachinetemplate.rs
+++ b/src/resources/awsmachinetemplate.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct AWSMachineTemplate {
+    manifest: Manifest,
+}
+
+impl Resource for AWSMachineTemplate {
+    fn from(manifest: Manifest) -> AWSMachineTemplate {
+        AWSMachineTemplate { manifest }
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        self.manifest.as_raw()
+    }
+}

--- a/src/resources/capicluster.rs
+++ b/src/resources/capicluster.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2022 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct CAPICluster {
+    manifest: Manifest,
+    ready: bool,
+}
+
+impl Resource for CAPICluster {
+    fn from(manifest: Manifest) -> CAPICluster {
+        let ready = manifest.has_condition_status("InfrastructureReady", "True");
+        CAPICluster { manifest, ready }
+    }
+
+    fn is_error(&self) -> bool {
+        !self.ready
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        self.manifest.as_raw()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_capicluster_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/clusters/testdata.yaml",
+        )).unwrap();
+        let cluster = <CAPICluster as Resource>::from(manifest);
+        assert_eq!(cluster.is_error(), false)
+    }
+
+    #[test]
+    fn test_capicluster_not_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/clusters/testdata-not-ready.yaml",
+        )).unwrap();
+        let cluster = <CAPICluster as Resource>::from(manifest);
+        assert_eq!(cluster.is_error(), true)
+    }
+}

--- a/src/resources/capimachine.rs
+++ b/src/resources/capimachine.rs
@@ -1,0 +1,97 @@
+// Copyright (C) 2022 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct CAPIMachine {
+    manifest: Manifest,
+    phase: String,
+    conditions: Vec<String>,
+}
+
+impl Resource for CAPIMachine {
+    fn from(manifest: Manifest) -> CAPIMachine {
+        let phase = manifest.as_yaml()["status"]["phase"]
+            .as_str()
+            .unwrap_or("Unknown")
+            .to_string();
+        let conditions = collect_conditions(&manifest);
+        CAPIMachine {
+            manifest,
+            phase,
+            conditions,
+        }
+    }
+
+    fn is_error(&self) -> bool {
+        self.phase != "Running"
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        self.manifest.as_raw()
+    }
+
+    fn conditions(&self) -> Vec<String> {
+        self.conditions.clone()
+    }
+}
+
+fn collect_conditions(manifest: &Manifest) -> Vec<String> {
+    let mut conditions = Vec::new();
+    if !manifest.has_condition_status("Ready", "True") {
+        conditions.push(String::from("NotReady"));
+    }
+    if manifest.has_condition_status("InfrastructureReady", "False") {
+        conditions.push(String::from("InfraNotReady"));
+    }
+    conditions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_capimachine_phase_running() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-0.yaml",
+        )).unwrap();
+        let machine = <CAPIMachine as Resource>::from(manifest);
+        assert_eq!(machine.is_error(), false);
+    }
+
+    #[test]
+    fn test_capimachine_conditions_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-0.yaml",
+        )).unwrap();
+        assert_eq!(collect_conditions(&manifest), Vec::<String>::new())
+    }
+
+    #[test]
+    fn test_capimachine_phase_failed() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-failed.yaml",
+        )).unwrap();
+        let machine = <CAPIMachine as Resource>::from(manifest);
+        assert_eq!(machine.is_error(), true);
+    }
+
+    #[test]
+    fn test_capimachine_conditions_not_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-failed.yaml",
+        )).unwrap();
+        assert_eq!(
+            collect_conditions(&manifest),
+            vec!["NotReady", "InfraNotReady"]
+        )
+    }
+}

--- a/src/resources/capimachinedeployment.rs
+++ b/src/resources/capimachinedeployment.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2022 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct CAPIMachineDeployment {
+    manifest: Manifest,
+    ready: bool,
+}
+
+impl Resource for CAPIMachineDeployment {
+    fn from(manifest: Manifest) -> CAPIMachineDeployment {
+        let ready = manifest.has_condition_status("Available", "True");
+        CAPIMachineDeployment { manifest, ready }
+    }
+
+    fn is_error(&self) -> bool {
+        !self.ready
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        self.manifest.as_raw()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_capimachinedeployment_available() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinedeployments/testdata-available.yaml",
+        )).unwrap();
+        let md = <CAPIMachineDeployment as Resource>::from(manifest);
+        assert_eq!(md.is_error(), false)
+    }
+
+    #[test]
+    fn test_capimachinedeployment_not_available() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinedeployments/testdata-not-available.yaml",
+        )).unwrap();
+        let md = <CAPIMachineDeployment as Resource>::from(manifest);
+        assert_eq!(md.is_error(), true)
+    }
+}

--- a/src/resources/capimachineset.rs
+++ b/src/resources/capimachineset.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2022 Red Hat, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::prelude::*;
+use crate::resources::Resource;
+
+#[derive(Debug, Clone)]
+pub struct CAPIMachineSet {
+    manifest: Manifest,
+    ready: bool,
+}
+
+impl Resource for CAPIMachineSet {
+    fn from(manifest: Manifest) -> CAPIMachineSet {
+        let ready = manifest.has_condition_status("MachinesReady", "True");
+        CAPIMachineSet { manifest, ready }
+    }
+
+    fn is_error(&self) -> bool {
+        !self.ready
+    }
+
+    fn name(&self) -> &String {
+        &self.manifest.name
+    }
+
+    fn raw(&self) -> &String {
+        self.manifest.as_raw()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_capimachineset_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinesets/testdata-worker-region-1.yaml",
+        )).unwrap();
+        let ms = <CAPIMachineSet as Resource>::from(manifest);
+        assert_eq!(ms.is_error(), false)
+    }
+
+    #[test]
+    fn test_capimachineset_not_ready() {
+        let manifest = Manifest::from(PathBuf::from(
+            "testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinesets/testdata-worker-empty.yaml",
+        )).unwrap();
+        let ms = <CAPIMachineSet as Resource>::from(manifest);
+        assert_eq!(ms.is_error(), true)
+    }
+}

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -1,7 +1,14 @@
 // Copyright (C) 2022 Red Hat, Inc.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+pub mod awscluster;
+pub mod awsmachine;
+pub mod awsmachinetemplate;
 pub mod baremetalhost;
+pub mod capicluster;
+pub mod capimachine;
+pub mod capimachinedeployment;
+pub mod capimachineset;
 pub mod certificatesigningrequest;
 pub mod clusterautoscaler;
 pub mod clusteroperator;
@@ -15,7 +22,14 @@ pub mod machineset;
 pub mod node;
 pub mod pod;
 
+pub use crate::resources::awscluster::AWSCluster;
+pub use crate::resources::awsmachine::AWSMachine;
+pub use crate::resources::awsmachinetemplate::AWSMachineTemplate;
 pub use crate::resources::baremetalhost::BareMetalHost;
+pub use crate::resources::capicluster::CAPICluster;
+pub use crate::resources::capimachine::CAPIMachine;
+pub use crate::resources::capimachinedeployment::CAPIMachineDeployment;
+pub use crate::resources::capimachineset::CAPIMachineSet;
 pub use crate::resources::certificatesigningrequest::CertificateSigningRequest;
 pub use crate::resources::clusterautoscaler::ClusterAutoscaler;
 pub use crate::resources::clusteroperator::ClusterOperator;

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/clusters/testdata-not-ready.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/clusters/testdata-not-ready.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  name: testdata-not-ready
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  clusterName: testdata
+status:
+  conditions:
+  - lastTransitionTime: "2022-01-01T00:00:00Z"
+    status: "False"
+    type: InfrastructureReady

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/clusters/testdata.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/clusters/testdata.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  creationTimestamp: "2026-05-29T09:11:17Z"
+  finalizers:
+    - cluster.cluster.x-k8s.io
+  generation: 1
+  name: testdata
+  namespace: openshift-cluster-api
+  resourceVersion: "44126"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  controlPlaneEndpoint:
+    host: api-int.testdata.XXXXXXXXXXXXXXXXXXXXXX
+    port: 6443
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AWSCluster
+    name: testdata
+status:
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: '* ControlPlaneAvailable: Please check controller logs for errors'
+      observedGeneration: 1
+      reason: AvailableUnknown
+      status: Unknown
+      type: Available
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: ProbeSucceeded
+      status: "True"
+      type: RemoteConnectionProbe
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: Ready
+      status: "True"
+      type: InfrastructureReady
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: Initialized
+      status: "True"
+      type: ControlPlaneInitialized
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: Please check controller logs for errors
+      observedGeneration: 1
+      reason: InternalError
+      status: Unknown
+      type: ControlPlaneAvailable
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NoWorkers
+      status: "True"
+      type: WorkersAvailable
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotRollingOut
+      status: "False"
+      type: RollingOut
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotRemediating
+      status: "False"
+      type: Remediating
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotScalingDown
+      status: "False"
+      type: ScalingDown
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotScalingUp
+      status: "False"
+      type: ScalingUp
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NoReplicas
+      status: "True"
+      type: ControlPlaneMachinesReady
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: Ready
+      status: "True"
+      type: WorkerMachinesReady
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NoReplicas
+      status: "True"
+      type: ControlPlaneMachinesUpToDate
+    - lastTransitionTime: "2026-05-29T09:31:20Z"
+      message: '* Machines testdata-worker-0, testdata-worker-1, testdata-worker-2: Condition UpToDate not yet reported'
+      observedGeneration: 1
+      reason: UpToDateUnknown
+      status: Unknown
+      type: WorkerMachinesUpToDate
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotDeleting
+      status: "False"
+      type: Deleting
+  controlPlane: {}
+  deprecated:
+    v1beta1:
+      conditions:
+        - lastTransitionTime: "2026-05-29T09:11:17Z"
+          status: "True"
+          type: Ready
+        - lastTransitionTime: "2026-05-29T09:11:17Z"
+          status: "True"
+          type: ControlPlaneInitialized
+        - lastTransitionTime: "2026-05-29T09:11:17Z"
+          status: "True"
+          type: InfrastructureReady
+  initialization:
+    infrastructureProvisioned: true
+  observedGeneration: 1
+  phase: Provisioned
+  workers:
+    availableReplicas: 3
+    desiredReplicas: 3
+    readyReplicas: 3
+    replicas: 3
+    upToDateReplicas: 0

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinedeployments/testdata-available.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinedeployments/testdata-available.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  name: testdata-available
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  clusterName: testdata
+status:
+  conditions:
+  - lastTransitionTime: "2022-01-01T00:00:00Z"
+    status: "True"
+    type: Available

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinedeployments/testdata-not-available.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinedeployments/testdata-not-available.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  name: testdata-not-available
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  clusterName: testdata
+status:
+  conditions:
+  - lastTransitionTime: "2022-01-01T00:00:00Z"
+    status: "False"
+    type: Available

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-0.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-0.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  creationTimestamp: "2026-05-29T09:11:18Z"
+  finalizers:
+    - machine.cluster.x-k8s.io
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    cluster.x-k8s.io/set-name: testdata-worker-region-1
+    machineconfiguration.openshift.io/osstream: rhel-9
+    node-role.kubernetes.io/worker: ""
+  name: testdata-worker-0
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      blockOwnerDeletion: true
+      controller: true
+      kind: MachineSet
+      name: testdata-worker-region-1
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "35514"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  bootstrap:
+    dataSecretName: worker-user-data
+  clusterName: testdata
+  deletion:
+    nodeDeletionTimeoutSeconds: 10
+  failureDomain: zone-1
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AWSMachine
+    name: testdata-worker-0
+  providerID: aws:///zone-1/i-0e8368547ff4f4ef4
+status:
+  addresses:
+    - address: ip-10-0-53-93.region-1.compute.internal
+      type: InternalDNS
+    - address: 10.0.53.93
+      type: InternalIP
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: Available
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: Ready
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: DataSecretProvided
+      status: "True"
+      type: BootstrapConfigReady
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: Ready
+      status: "True"
+      type: InfrastructureReady
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: NodeHealthy
+      status: "True"
+      type: NodeHealthy
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: NodeReady
+      status: "True"
+      type: NodeReady
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotUpdating
+      status: "False"
+      type: Updating
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotDeleting
+      status: "False"
+      type: Deleting
+  deprecated:
+    v1beta1:
+      conditions:
+        - lastTransitionTime: "2026-05-29T09:11:52Z"
+          status: "True"
+          type: Ready
+        - lastTransitionTime: "2026-05-29T09:11:52Z"
+          status: "True"
+          type: InfrastructureReady
+        - lastTransitionTime: "2026-05-29T09:15:52Z"
+          status: "True"
+          type: NodeHealthy
+  initialization:
+    infrastructureProvisioned: true
+  lastUpdated: "2026-05-29T09:14:12Z"
+  nodeInfo:
+    architecture: amd64
+    bootID: a22dbf72-a410-4b71-8e73-2d4d7f157189
+    containerRuntimeVersion: cri-o://1.35.3-13.rhaos4.22.git5a749ba.el9
+    kernelVersion: 5.14.0-687.11.1.el9_8.x86_64
+    kubeProxyVersion: ""
+    kubeletVersion: v1.35.5
+    machineID: ec205784fa28816001380b16bbefa737
+    operatingSystem: linux
+    osImage: Red Hat Enterprise Linux CoreOS 9.8.20260526-0 (Plow)
+    systemUUID: ec205784-fa28-8160-0138-0b16bbefa737
+  nodeRef:
+    name: ip-10-0-53-93.region-1.compute.internal
+  observedGeneration: 2
+  phase: Running

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-1.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-1.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  creationTimestamp: "2026-05-29T09:11:17Z"
+  finalizers:
+    - machine.cluster.x-k8s.io
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    cluster.x-k8s.io/set-name: testdata-worker-region-1
+    machineconfiguration.openshift.io/osstream: rhel-9
+    node-role.kubernetes.io/worker: ""
+  name: testdata-worker-1
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      blockOwnerDeletion: true
+      controller: true
+      kind: MachineSet
+      name: testdata-worker-region-1
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "35424"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  bootstrap:
+    dataSecretName: worker-user-data
+  clusterName: testdata
+  deletion:
+    nodeDeletionTimeoutSeconds: 10
+  failureDomain: zone-1
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AWSMachine
+    name: testdata-worker-1
+  providerID: aws:///zone-1/i-02116218eccbef72f
+status:
+  addresses:
+    - address: ip-10-0-61-15.region-1.compute.internal
+      type: InternalDNS
+    - address: 10.0.61.15
+      type: InternalIP
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: Available
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: Ready
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: DataSecretProvided
+      status: "True"
+      type: BootstrapConfigReady
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: Ready
+      status: "True"
+      type: InfrastructureReady
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: NodeHealthy
+      status: "True"
+      type: NodeHealthy
+    - lastTransitionTime: "2026-05-29T09:15:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: NodeReady
+      status: "True"
+      type: NodeReady
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotUpdating
+      status: "False"
+      type: Updating
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotDeleting
+      status: "False"
+      type: Deleting
+  deprecated:
+    v1beta1:
+      conditions:
+        - lastTransitionTime: "2026-05-29T09:11:52Z"
+          status: "True"
+          type: Ready
+        - lastTransitionTime: "2026-05-29T09:11:52Z"
+          status: "True"
+          type: InfrastructureReady
+        - lastTransitionTime: "2026-05-29T09:15:52Z"
+          status: "True"
+          type: NodeHealthy
+  initialization:
+    infrastructureProvisioned: true
+  lastUpdated: "2026-05-29T09:14:33Z"
+  nodeInfo:
+    architecture: amd64
+    bootID: f3068149-2fb0-4c7d-b0c1-5ead1db8c889
+    containerRuntimeVersion: cri-o://1.35.3-13.rhaos4.22.git5a749ba.el9
+    kernelVersion: 5.14.0-687.11.1.el9_8.x86_64
+    kubeProxyVersion: ""
+    kubeletVersion: v1.35.5
+    machineID: ec2a805f3f79919452cbecc18bb68e15
+    operatingSystem: linux
+    osImage: Red Hat Enterprise Linux CoreOS 9.8.20260526-0 (Plow)
+    systemUUID: ec2a805f-3f79-9194-52cb-ecc18bb68e15
+  nodeRef:
+    name: ip-10-0-61-15.region-1.compute.internal
+  observedGeneration: 2
+  phase: Running

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-2.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-2.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  creationTimestamp: "2026-05-29T09:11:17Z"
+  finalizers:
+    - machine.cluster.x-k8s.io
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    cluster.x-k8s.io/set-name: testdata-worker-region-1
+    machineconfiguration.openshift.io/osstream: rhel-9
+    node-role.kubernetes.io/worker: ""
+  name: testdata-worker-2
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      blockOwnerDeletion: true
+      controller: true
+      kind: MachineSet
+      name: testdata-worker-region-1
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "35822"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  bootstrap:
+    dataSecretName: worker-user-data
+  clusterName: testdata
+  deletion:
+    nodeDeletionTimeoutSeconds: 10
+  failureDomain: zone-1
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AWSMachine
+    name: testdata-worker-2
+  providerID: aws:///zone-1/i-05df28058d0f119a9
+status:
+  addresses:
+    - address: ip-10-0-18-138.region-1.compute.internal
+      type: InternalDNS
+    - address: 10.0.18.138
+      type: InternalIP
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:16:00Z"
+      message: ""
+      observedGeneration: 2
+      reason: Available
+      status: "True"
+      type: Available
+    - lastTransitionTime: "2026-05-29T09:16:00Z"
+      message: ""
+      observedGeneration: 2
+      reason: Ready
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: DataSecretProvided
+      status: "True"
+      type: BootstrapConfigReady
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      message: ""
+      observedGeneration: 2
+      reason: Ready
+      status: "True"
+      type: InfrastructureReady
+    - lastTransitionTime: "2026-05-29T09:16:00Z"
+      message: ""
+      observedGeneration: 2
+      reason: NodeHealthy
+      status: "True"
+      type: NodeHealthy
+    - lastTransitionTime: "2026-05-29T09:16:00Z"
+      message: ""
+      observedGeneration: 2
+      reason: NodeReady
+      status: "True"
+      type: NodeReady
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotUpdating
+      status: "False"
+      type: Updating
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 2
+      reason: NotDeleting
+      status: "False"
+      type: Deleting
+  deprecated:
+    v1beta1:
+      conditions:
+        - lastTransitionTime: "2026-05-29T09:11:52Z"
+          status: "True"
+          type: Ready
+        - lastTransitionTime: "2026-05-29T09:11:52Z"
+          status: "True"
+          type: InfrastructureReady
+        - lastTransitionTime: "2026-05-29T09:16:00Z"
+          status: "True"
+          type: NodeHealthy
+  initialization:
+    infrastructureProvisioned: true
+  lastUpdated: "2026-05-29T09:14:36Z"
+  nodeInfo:
+    architecture: amd64
+    bootID: 2c3ceaa1-ec6d-4fee-9414-656ceb18960d
+    containerRuntimeVersion: cri-o://1.35.3-13.rhaos4.22.git5a749ba.el9
+    kernelVersion: 5.14.0-687.11.1.el9_8.x86_64
+    kubeProxyVersion: ""
+    kubeletVersion: v1.35.5
+    machineID: ec2bf914803997c5c369b5c059f35e4c
+    operatingSystem: linux
+    osImage: Red Hat Enterprise Linux CoreOS 9.8.20260526-0 (Plow)
+    systemUUID: ec2bf914-8039-97c5-c369-b5c059f35e4c
+  nodeRef:
+    name: ip-10-0-18-138.region-1.compute.internal
+  observedGeneration: 2
+  phase: Running

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-failed.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machines/testdata-worker-failed.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    cluster.x-k8s.io/set-name: testdata-worker-region-1
+    node-role.kubernetes.io/worker: ""
+  name: testdata-worker-failed
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  bootstrap:
+    dataSecretName: worker-user-data
+  clusterName: testdata
+  failureDomain: zone-1
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: AWSMachine
+    name: testdata-worker-failed
+status:
+  conditions:
+  - lastTransitionTime: "2022-01-01T00:00:00Z"
+    status: "False"
+    type: Ready
+  - lastTransitionTime: "2022-01-01T00:00:00Z"
+    status: "False"
+    type: InfrastructureReady
+  phase: Failed

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinesets/testdata-worker-empty.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinesets/testdata-worker-empty.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineSet
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+  name: testdata-worker-zone-2
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  clusterName: testdata
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: testdata
+status: {}

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinesets/testdata-worker-region-1.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/cluster.x-k8s.io/machinesets/testdata-worker-region-1.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineSet
+metadata:
+  creationTimestamp: "2026-05-29T08:44:23Z"
+  finalizers:
+    - cluster.x-k8s.io/machineset
+  generation: 1
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    machineconfiguration.openshift.io/osstream: rhel-9
+  name: testdata-worker-region-1
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      name: testdata
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "47923"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  clusterName: testdata
+  replicas: 3
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: testdata
+      cluster.x-k8s.io/set-name: testdata-worker-region-1
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: testdata
+        cluster.x-k8s.io/set-name: testdata-worker-region-1
+        machineconfiguration.openshift.io/osstream: rhel-9
+        node-role.kubernetes.io/worker: ""
+    spec:
+      bootstrap:
+        dataSecretName: worker-user-data
+      clusterName: testdata
+      failureDomain: zone-1
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: AWSMachineTemplate
+        name: testdata-worker-region-1
+status:
+  availableReplicas: 3
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotRemediating
+      status: "False"
+      type: Remediating
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotScalingDown
+      status: "False"
+      type: ScalingDown
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotScalingUp
+      status: "False"
+      type: ScalingUp
+    - lastTransitionTime: "2026-05-29T09:16:00Z"
+      message: ""
+      observedGeneration: 1
+      reason: Ready
+      status: "True"
+      type: MachinesReady
+    - lastTransitionTime: "2026-05-29T09:11:33Z"
+      message: '* Machines testdata-worker-0, testdata-worker-1, testdata-worker-2: Condition UpToDate not yet reported'
+      observedGeneration: 1
+      reason: UpToDateUnknown
+      status: Unknown
+      type: MachinesUpToDate
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      message: ""
+      observedGeneration: 1
+      reason: NotDeleting
+      status: "False"
+      type: Deleting
+  deprecated:
+    v1beta1:
+      availableReplicas: 3
+      conditions:
+        - lastTransitionTime: "2026-05-29T09:16:00Z"
+          status: "True"
+          type: Ready
+        - lastTransitionTime: "2026-05-29T09:11:18Z"
+          status: "True"
+          type: MachinesCreated
+        - lastTransitionTime: "2026-05-29T09:11:52Z"
+          status: "True"
+          type: MachinesReady
+        - lastTransitionTime: "2026-05-29T09:16:00Z"
+          status: "True"
+          type: Resized
+      fullyLabeledReplicas: 3
+      readyReplicas: 3
+  observedGeneration: 1
+  readyReplicas: 3
+  replicas: 3
+  selector: cluster.x-k8s.io/cluster-name=testdata,cluster.x-k8s.io/set-name=testdata-worker-region-1
+  upToDateReplicas: 0

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsclusters/testdata-not-ready.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsclusters/testdata-not-ready.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSCluster
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  name: testdata-not-ready
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec: {}
+status:
+  ready: false

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsclusters/testdata.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsclusters/testdata.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSCluster
+metadata:
+  annotations:
+    cluster.x-k8s.io/managed-by: cluster-capi-operator-infracluster-controller
+  creationTimestamp: "2026-05-29T09:01:52Z"
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+  name: testdata
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: testdata
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "31558"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  bastion:
+    allowedCIDRBlocks:
+      - 0.0.0.0/0
+      - ::/0
+    enabled: false
+  controlPlaneEndpoint:
+    host: api-int.testdata.XXXXXXXXXXXXXXXXXXXXXX
+    port: 6443
+  controlPlaneLoadBalancer:
+    crossZoneLoadBalancing: false
+    loadBalancerType: nlb
+    name: testdata-int
+    scheme: internal
+  identityRef:
+    kind: AWSClusterControllerIdentity
+    name: default
+  network:
+    cni:
+      cniIngressRules:
+        - description: bgp (calico)
+          fromPort: 179
+          protocol: tcp
+          toPort: 179
+        - description: IP-in-IP (calico)
+          fromPort: -1
+          protocol: "4"
+          toPort: 65535
+    vpc:
+      availabilityZoneSelection: Ordered
+      availabilityZoneUsageLimit: 3
+      subnetSchema: PreferPrivate
+  region: region-1
+  secondaryControlPlaneLoadBalancer:
+    crossZoneLoadBalancing: false
+    loadBalancerType: nlb
+    name: testdata-ext
+    scheme: internet-facing
+status:
+  ready: true

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-0.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-0.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachine
+metadata:
+  annotations:
+    cluster.x-k8s.io/cloned-from-groupkind: AWSMachineTemplate.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/cloned-from-name: testdata-worker-region-1
+    sigs.k8s.io/cluster-api-provider-aws-last-applied-security-groups: '{"sg-02506528be4344646":{},"sg-087bd474fe5805319":{}}'
+    sigs.k8s.io/cluster-api-provider-aws-last-applied-tags: '{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"}'
+    sigs.k8s.io/cluster-api-provider-last-applied-tags-on-volumes: '{"vol-0c6b6a40b721f0b98":{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"},"vol-0fedc152fa465af17":{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"}}'
+  creationTimestamp: "2026-05-29T09:11:18Z"
+  finalizers:
+    - awsmachine.infrastructure.cluster.x-k8s.io
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    cluster.x-k8s.io/set-name: testdata-worker-region-1
+    machineconfiguration.openshift.io/osstream: rhel-9
+    node-role.kubernetes.io/worker: ""
+  name: testdata-worker-0
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      blockOwnerDeletion: true
+      controller: true
+      kind: Machine
+      name: testdata-worker-0
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "42509"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  additionalSecurityGroups:
+    - filters:
+        - name: tag:Name
+          values:
+            - testdata-node
+    - filters:
+        - name: tag:Name
+          values:
+            - testdata-lb
+  additionalTags:
+    ci-nat-replace: "true"
+    clusterName: testdata
+    expirationDate: 2026-05-29T16:19+00:00
+    keyA: valueA
+    keyB: valueB
+    keyC: valueC
+    kubernetes.io/cluster/testdata: owned
+  ami:
+    id: ami-089c98e2d700adb1e
+  cloudInit: {}
+  hostAffinity: default
+  iamInstanceProfile: testdata-worker-profile
+  ignition:
+    storageType: UnencryptedUserData
+    version: "3.2"
+  instanceID: i-0e8368547ff4f4ef4
+  instanceMetadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIpv6: disabled
+    httpPutResponseHopLimit: 1
+    httpTokens: optional
+    instanceMetadataTags: disabled
+  instanceType: m6a.xlarge
+  providerID: aws:///zone-1/i-0e8368547ff4f4ef4
+  publicIP: false
+  rootVolume:
+    encrypted: true
+    size: 120
+    type: gp3
+  sshKeyName: ""
+  subnet:
+    filters:
+      - name: tag:Name
+        values:
+          - testdata-subnet-private-zone-1
+status:
+  addresses:
+    - address: ip-10-0-53-93.region-1.compute.internal
+      type: InternalDNS
+    - address: 10.0.53.93
+      type: InternalIP
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      status: "True"
+      type: InstanceReady
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:21Z"
+      status: "True"
+      type: SecurityGroupsReady
+  instanceState: running
+  ready: true

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-1.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-1.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachine
+metadata:
+  annotations:
+    cluster.x-k8s.io/cloned-from-groupkind: AWSMachineTemplate.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/cloned-from-name: testdata-worker-region-1
+    sigs.k8s.io/cluster-api-provider-aws-last-applied-security-groups: '{"sg-02506528be4344646":{},"sg-087bd474fe5805319":{}}'
+    sigs.k8s.io/cluster-api-provider-aws-last-applied-tags: '{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"}'
+    sigs.k8s.io/cluster-api-provider-last-applied-tags-on-volumes: '{"vol-01e733bd313c0e4e6":{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"}}'
+  creationTimestamp: "2026-05-29T09:11:17Z"
+  finalizers:
+    - awsmachine.infrastructure.cluster.x-k8s.io
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    cluster.x-k8s.io/set-name: testdata-worker-region-1
+    machineconfiguration.openshift.io/osstream: rhel-9
+    node-role.kubernetes.io/worker: ""
+  name: testdata-worker-1
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      blockOwnerDeletion: true
+      controller: true
+      kind: Machine
+      name: testdata-worker-1
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "31917"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  additionalSecurityGroups:
+    - filters:
+        - name: tag:Name
+          values:
+            - testdata-node
+    - filters:
+        - name: tag:Name
+          values:
+            - testdata-lb
+  additionalTags:
+    ci-nat-replace: "true"
+    clusterName: testdata
+    expirationDate: 2026-05-29T16:19+00:00
+    keyA: valueA
+    keyB: valueB
+    keyC: valueC
+    kubernetes.io/cluster/testdata: owned
+  ami:
+    id: ami-089c98e2d700adb1e
+  cloudInit: {}
+  hostAffinity: default
+  iamInstanceProfile: testdata-worker-profile
+  ignition:
+    storageType: UnencryptedUserData
+    version: "3.2"
+  instanceID: i-02116218eccbef72f
+  instanceMetadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIpv6: disabled
+    httpPutResponseHopLimit: 1
+    httpTokens: optional
+    instanceMetadataTags: disabled
+  instanceType: m6a.xlarge
+  providerID: aws:///zone-1/i-02116218eccbef72f
+  publicIP: false
+  rootVolume:
+    encrypted: true
+    size: 120
+    type: gp3
+  sshKeyName: ""
+  subnet:
+    filters:
+      - name: tag:Name
+        values:
+          - testdata-subnet-private-zone-1
+status:
+  addresses:
+    - address: ip-10-0-61-15.region-1.compute.internal
+      type: InternalDNS
+    - address: 10.0.61.15
+      type: InternalIP
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      status: "True"
+      type: InstanceReady
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:21Z"
+      status: "True"
+      type: SecurityGroupsReady
+  instanceState: running
+  ready: true

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-2.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-2.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachine
+metadata:
+  annotations:
+    cluster.x-k8s.io/cloned-from-groupkind: AWSMachineTemplate.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/cloned-from-name: testdata-worker-region-1
+    sigs.k8s.io/cluster-api-provider-aws-last-applied-security-groups: '{"sg-02506528be4344646":{},"sg-087bd474fe5805319":{}}'
+    sigs.k8s.io/cluster-api-provider-aws-last-applied-tags: '{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"}'
+    sigs.k8s.io/cluster-api-provider-last-applied-tags-on-volumes: '{"vol-0137e2bb683101880":{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"},"vol-0452fb57c3a4878d0":{"ci-nat-replace":"true","clusterName":"testdata","expirationDate":"2026-05-29T16:19+00:00","keyA":"valueA","keyB":"valueB","keyC":"valueC","kubernetes.io/cluster/testdata":"owned"}}'
+  creationTimestamp: "2026-05-29T09:11:17Z"
+  finalizers:
+    - awsmachine.infrastructure.cluster.x-k8s.io
+  generation: 2
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+    cluster.x-k8s.io/set-name: testdata-worker-region-1
+    machineconfiguration.openshift.io/osstream: rhel-9
+    node-role.kubernetes.io/worker: ""
+  name: testdata-worker-2
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      blockOwnerDeletion: true
+      controller: true
+      kind: Machine
+      name: testdata-worker-2
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "42508"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  additionalSecurityGroups:
+    - filters:
+        - name: tag:Name
+          values:
+            - testdata-node
+    - filters:
+        - name: tag:Name
+          values:
+            - testdata-lb
+  additionalTags:
+    ci-nat-replace: "true"
+    clusterName: testdata
+    expirationDate: 2026-05-29T16:19+00:00
+    keyA: valueA
+    keyB: valueB
+    keyC: valueC
+    kubernetes.io/cluster/testdata: owned
+  ami:
+    id: ami-089c98e2d700adb1e
+  cloudInit: {}
+  hostAffinity: default
+  iamInstanceProfile: testdata-worker-profile
+  ignition:
+    storageType: UnencryptedUserData
+    version: "3.2"
+  instanceID: i-05df28058d0f119a9
+  instanceMetadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIpv6: disabled
+    httpPutResponseHopLimit: 1
+    httpTokens: optional
+    instanceMetadataTags: disabled
+  instanceType: m6a.xlarge
+  providerID: aws:///zone-1/i-05df28058d0f119a9
+  publicIP: false
+  rootVolume:
+    encrypted: true
+    size: 120
+    type: gp3
+  sshKeyName: ""
+  subnet:
+    filters:
+      - name: tag:Name
+        values:
+          - testdata-subnet-private-zone-1
+status:
+  addresses:
+    - address: ip-10-0-18-138.region-1.compute.internal
+      type: InternalDNS
+    - address: 10.0.18.138
+      type: InternalIP
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      status: "True"
+      type: Ready
+    - lastTransitionTime: "2026-05-29T09:11:52Z"
+      status: "True"
+      type: InstanceReady
+    - lastTransitionTime: "2026-05-29T09:11:18Z"
+      reason: NotPaused
+      status: "False"
+      type: Paused
+    - lastTransitionTime: "2026-05-29T09:11:21Z"
+      status: "True"
+      type: SecurityGroupsReady
+  instanceState: running
+  ready: true

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-not-ready.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachines/testdata-worker-not-ready.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachine
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  name: testdata-worker-not-ready
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec: {}
+status:
+  ready: false

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachinetemplates/testdata-worker-empty.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachinetemplates/testdata-worker-empty.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  creationTimestamp: "2022-01-01T00:00:00Z"
+  name: testdata-worker-zone-2
+  namespace: openshift-cluster-api
+  resourceVersion: "16606"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  template:
+    spec: {}

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachinetemplates/testdata-worker-region-1.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/infrastructure.cluster.x-k8s.io/awsmachinetemplates/testdata-worker-region-1.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+metadata:
+  creationTimestamp: "2026-05-29T09:02:35Z"
+  generation: 1
+  labels:
+    cluster.x-k8s.io/cluster-name: testdata
+  name: testdata-worker-region-1
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta2
+      kind: Cluster
+      name: testdata
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "31589"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  template:
+    metadata: {}
+    spec:
+      additionalSecurityGroups:
+        - filters:
+            - name: tag:Name
+              values:
+                - testdata-node
+        - filters:
+            - name: tag:Name
+              values:
+                - testdata-lb
+      additionalTags:
+        ci-nat-replace: "true"
+        clusterName: testdata
+        expirationDate: 2026-05-29T16:19+00:00
+        keyA: valueA
+        keyB: valueB
+        keyC: valueC
+        kubernetes.io/cluster/testdata: owned
+      ami:
+        id: ami-089c98e2d700adb1e
+      cloudInit: {}
+      hostAffinity: default
+      iamInstanceProfile: testdata-worker-profile
+      ignition:
+        storageType: UnencryptedUserData
+        version: "3.2"
+      instanceMetadataOptions:
+        httpEndpoint: enabled
+        httpProtocolIpv6: disabled
+        httpPutResponseHopLimit: 1
+        httpTokens: optional
+        instanceMetadataTags: disabled
+      instanceType: m6a.xlarge
+      publicIP: false
+      rootVolume:
+        encrypted: true
+        size: 120
+        type: gp3
+      sshKeyName: ""
+      subnet:
+        filters:
+          - name: tag:Name
+            values:
+              - testdata-subnet-private-zone-1
+status:
+  capacity:
+    cpu: "4"
+    memory: 16Gi
+  conditions:
+    - lastTransitionTime: "2026-05-29T09:11:17Z"
+      reason: NotPaused
+      status: "False"
+      type: Paused
+  nodeInfo:
+    architecture: amd64
+    operatingSystem: linux

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capa-controller-manager-587d865769-598bl/capa-controller-manager-587d865769-598bl.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capa-controller-manager-587d865769-598bl/capa-controller-manager-587d865769-598bl.yaml
@@ -1,0 +1,255 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    iam.amazonaws.com/role: ""
+    k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.129.0.49/23"],"mac_address":"0a:58:0a:81:00:31","gateway_ips":["10.129.0.1"],"routes":[{"dest":"10.128.0.0/14","nextHop":"10.129.0.1"},{"dest":"172.30.0.0/16","nextHop":"10.129.0.1"},{"dest":"169.254.0.5/32","nextHop":"10.129.0.1"},{"dest":"100.64.0.0/16","nextHop":"10.129.0.1"}],"ip_address":"10.129.0.49/23","gateway_ip":"10.129.0.1","role":"primary"}}'
+    k8s.v1.cni.cncf.io/network-status: |-
+      [{
+          "name": "ovn-kubernetes",
+          "interface": "eth0",
+          "ips": [
+              "10.129.0.49"
+          ],
+          "mac": "0a:58:0a:81:00:31",
+          "default": true,
+          "dns": {}
+      }]
+    openshift.io/required-scc: restricted-v2
+  creationTimestamp: "2026-05-29T09:06:16Z"
+  generateName: capa-controller-manager-587d865769-
+  generation: 1
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
+    control-plane: capa-controller-manager
+    topology.kubernetes.io/region: region-1
+    topology.kubernetes.io/zone: zone-1
+  name: capa-controller-manager-587d865769-598bl
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ReplicaSet
+      name: capa-controller-manager-587d865769
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "26836"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+          weight: 10
+        - preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+          weight: 10
+  containers:
+    - args:
+        - --leader-elect
+        - --feature-gates=EKS=true,EKSEnableIAM=false,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=false,MachinePoolMachines=false,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,BootstrapFormatIgnition=true,ExternalResourceGC=true,AlternativeGCStrategy=false,TagUnmanagedNetworkResources=true,ROSA=false
+        - --v=0
+        - --diagnostics-address=:8443
+        - --insecure-diagnostics=false
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      env:
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /home/.aws/credentials
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imagePullPolicy: Always
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /healthz
+          port: healthz
+          scheme: HTTP
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 1
+      name: manager
+      ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+      readinessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /readyz
+          port: healthz
+          scheme: HTTP
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 1
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsGroup: 65532
+        runAsUser: 65532
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /home/.aws
+          name: credentials
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-r7q68
+          readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: ip-10-0-33-182.region-1.compute.internal
+  preemptionPolicy: PreemptLowerPriority
+  priority: 2000000000
+  priorityClassName: system-cluster-critical
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext:
+    fsGroup: 1000
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccount: capa-controller-manager
+  serviceAccountName: capa-controller-manager
+  terminationGracePeriodSeconds: 10
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoSchedule
+      key: node.kubernetes.io/memory-pressure
+      operator: Exists
+  volumes:
+    - name: cert
+      secret:
+        defaultMode: 420
+        secretName: capa-webhook-service-cert
+    - name: credentials
+      secret:
+        defaultMode: 420
+        secretName: capa-manager-bootstrap-credentials
+    - name: kube-api-access-r7q68
+      projected:
+        defaultMode: 420
+        sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+                - key: ca.crt
+                  path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+          - configMap:
+              items:
+                - key: service-ca.crt
+                  path: service-ca.crt
+              name: openshift-service-ca.crt
+status:
+  conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:06:24Z"
+      observedGeneration: 1
+      status: "True"
+      type: PodReadyToStartContainers
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:06:16Z"
+      observedGeneration: 1
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:06:24Z"
+      observedGeneration: 1
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:06:24Z"
+      observedGeneration: 1
+      status: "True"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:06:16Z"
+      observedGeneration: 1
+      status: "True"
+      type: PodScheduled
+  containerStatuses:
+    - allocatedResources:
+        cpu: 10m
+        memory: 50Mi
+      containerID: cri-o://fake
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imageID: quay.io/openshift-release-dev/ocp-v4.0-fake
+      lastState: {}
+      name: manager
+      ready: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      restartCount: 0
+      started: true
+      state:
+        running:
+          startedAt: "2026-05-29T09:06:23Z"
+      user:
+        linux:
+          gid: 65532
+          supplementalGroups:
+            - 65532
+            - 1000
+          uid: 65532
+      volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+          recursiveReadOnly: Disabled
+        - mountPath: /home/.aws
+          name: credentials
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-r7q68
+          readOnly: true
+          recursiveReadOnly: Disabled
+  hostIP: 10.0.33.182
+  hostIPs:
+    - ip: 10.0.33.182
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.129.0.49
+  podIPs:
+    - ip: 10.129.0.49
+  qosClass: Burstable
+  startTime: "2026-05-29T09:06:16Z"

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capa-controller-manager-587d865769-598bl/manager/manager/logs/current.log
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capa-controller-manager-587d865769-598bl/manager/manager/logs/current.log
@@ -1,0 +1,1 @@
+capa-controller-manager-587d865769-598bl manager logs

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controller-manager-54ff787d7f-vm79h/capi-controller-manager-54ff787d7f-vm79h.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controller-manager-54ff787d7f-vm79h/capi-controller-manager-54ff787d7f-vm79h.yaml
@@ -1,0 +1,254 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.129.0.33/23"],"mac_address":"0a:58:0a:81:00:21","gateway_ips":["10.129.0.1"],"routes":[{"dest":"10.128.0.0/14","nextHop":"10.129.0.1"},{"dest":"172.30.0.0/16","nextHop":"10.129.0.1"},{"dest":"169.254.0.5/32","nextHop":"10.129.0.1"},{"dest":"100.64.0.0/16","nextHop":"10.129.0.1"}],"ip_address":"10.129.0.33/23","gateway_ip":"10.129.0.1","role":"primary"}}'
+    k8s.v1.cni.cncf.io/network-status: |-
+      [{
+          "name": "ovn-kubernetes",
+          "interface": "eth0",
+          "ips": [
+              "10.129.0.33"
+          ],
+          "mac": "0a:58:0a:81:00:21",
+          "default": true,
+          "dns": {}
+      }]
+    openshift.io/required-scc: restricted-v2
+  creationTimestamp: "2026-05-29T08:54:11Z"
+  generateName: capi-controller-manager-54ff787d7f-
+  generation: 1
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    control-plane: controller-manager
+    topology.kubernetes.io/region: region-1
+    topology.kubernetes.io/zone: zone-1
+  name: capi-controller-manager-54ff787d7f-vm79h
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ReplicaSet
+      name: capi-controller-manager-54ff787d7f
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "24252"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  containers:
+    - args:
+        - --leader-elect
+        - --diagnostics-address=:8443
+        - --insecure-diagnostics=false
+        - --feature-gates=MachinePool=true,ClusterTopology=false,RuntimeSDK=false,MachineSetPreflightChecks=false
+        - --additional-sync-machine-labels=.*
+        - --additional-sync-machine-annotations=.*
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      command:
+        - /manager
+      env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imagePullPolicy: Always
+      livenessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /healthz
+          port: healthz
+          scheme: HTTP
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 1
+      name: manager
+      ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+      readinessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: /readyz
+          port: healthz
+          scheme: HTTP
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 1
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        runAsGroup: 65532
+        runAsUser: 65532
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-wrmwg
+          readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: ip-10-0-33-182.region-1.compute.internal
+  preemptionPolicy: PreemptLowerPriority
+  priority: 2000000000
+  priorityClassName: system-cluster-critical
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccount: capi-manager
+  serviceAccountName: capi-manager
+  terminationGracePeriodSeconds: 10
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoSchedule
+      key: node.kubernetes.io/memory-pressure
+      operator: Exists
+  volumes:
+    - name: cert
+      secret:
+        defaultMode: 420
+        secretName: capi-webhook-service-cert
+    - name: kube-api-access-wrmwg
+      projected:
+        defaultMode: 420
+        sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+                - key: ca.crt
+                  path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+          - configMap:
+              items:
+                - key: service-ca.crt
+                  path: service-ca.crt
+              name: openshift-service-ca.crt
+status:
+  conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T08:54:14Z"
+      observedGeneration: 1
+      status: "True"
+      type: PodReadyToStartContainers
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T08:54:11Z"
+      observedGeneration: 1
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:05:12Z"
+      observedGeneration: 1
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:05:12Z"
+      observedGeneration: 1
+      status: "True"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T08:54:11Z"
+      observedGeneration: 1
+      status: "True"
+      type: PodScheduled
+  containerStatuses:
+    - allocatedResources:
+        cpu: 10m
+        memory: 50Mi
+      containerID: cri-o://fake
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imageID: quay.io/openshift-release-dev/ocp-v4.0-fake
+      lastState:
+        terminated:
+          containerID: cri-o://fake
+          exitCode: 1
+          finishedAt: "2026-05-29T09:03:50Z"
+          reason: Error
+          startedAt: "2026-05-29T08:55:54Z"
+      name: manager
+      ready: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      restartCount: 5
+      started: true
+      state:
+        running:
+          startedAt: "2026-05-29T09:05:12Z"
+      user:
+        linux:
+          gid: 65532
+          supplementalGroups:
+            - 65532
+          uid: 65532
+      volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+          recursiveReadOnly: Disabled
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-wrmwg
+          readOnly: true
+          recursiveReadOnly: Disabled
+  hostIP: 10.0.33.182
+  hostIPs:
+    - ip: 10.0.33.182
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.129.0.33
+  podIPs:
+    - ip: 10.129.0.33
+  qosClass: Burstable
+  startTime: "2026-05-29T08:54:11Z"

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controller-manager-54ff787d7f-vm79h/manager/manager/logs/current.log
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controller-manager-54ff787d7f-vm79h/manager/manager/logs/current.log
@@ -1,0 +1,1 @@
+capi-controller-manager-54ff787d7f-vm79h manager logs

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controllers-74b8964d87-l854p/capi-controllers-74b8964d87-l854p.yaml
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controllers-74b8964d87-l854p/capi-controllers-74b8964d87-l854p.yaml
@@ -1,0 +1,289 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.130.0.9/23"],"mac_address":"0a:58:0a:82:00:09","gateway_ips":["10.130.0.1"],"routes":[{"dest":"10.128.0.0/14","nextHop":"10.130.0.1"},{"dest":"172.30.0.0/16","nextHop":"10.130.0.1"},{"dest":"169.254.0.5/32","nextHop":"10.130.0.1"},{"dest":"100.64.0.0/16","nextHop":"10.130.0.1"}],"ip_address":"10.130.0.9/23","gateway_ip":"10.130.0.1","role":"primary"}}'
+    k8s.v1.cni.cncf.io/network-status: |-
+      [{
+          "name": "ovn-kubernetes",
+          "interface": "eth0",
+          "ips": [
+              "10.130.0.9"
+          ],
+          "mac": "0a:58:0a:82:00:09",
+          "default": true,
+          "dns": {}
+      }]
+    openshift.io/required-scc: restricted-v2
+  creationTimestamp: "2026-05-29T08:36:04Z"
+  generateName: capi-controllers-74b8964d87-
+  generation: 1
+  labels:
+    k8s-app: capi-controllers
+    topology.kubernetes.io/region: region-1
+    topology.kubernetes.io/zone: zone-1
+  name: capi-controllers-74b8964d87-l854p
+  namespace: openshift-cluster-api
+  ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ReplicaSet
+      name: capi-controllers-74b8964d87
+      uid: 00000000-0000-0000-0000-000000000000
+  resourceVersion: "29439"
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  containers:
+    - args:
+        - --diagnostics-address=:8443
+      command:
+        - /capi-controllers
+      env:
+        - name: RELEASE_VERSION
+          value: 5.0.0-0.ci-2026-05-29-081704-test-ci-op-k0d03pt8-latest
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imagePullPolicy: IfNotPresent
+      name: capi-controllers
+      ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8443
+          name: diagnostics-o
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz-o
+          protocol: TCP
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-cert
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-5zjxk
+          readOnly: true
+    - args:
+        - --diagnostics-address=:8442
+        - --health-addr=:9441
+      command:
+        - /machine-api-migration
+      env:
+        - name: RELEASE_VERSION
+          value: 5.0.0-0.ci-2026-05-29-081704-test-ci-op-k0d03pt8-latest
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imagePullPolicy: IfNotPresent
+      name: machine-api-migration
+      ports:
+        - containerPort: 8442
+          name: diagnostics-m
+          protocol: TCP
+        - containerPort: 9441
+          name: healthz-m
+          protocol: TCP
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-cert
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-5zjxk
+          readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: ip-10-0-23-213.region-1.compute.internal
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  preemptionPolicy: PreemptLowerPriority
+  priority: 2000001000
+  priorityClassName: system-node-critical
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: capi-controllers
+  serviceAccountName: capi-controllers
+  terminationGracePeriodSeconds: 30
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Exists
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Exists
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoSchedule
+      key: node.kubernetes.io/memory-pressure
+      operator: Exists
+  volumes:
+    - name: cert
+      secret:
+        defaultMode: 420
+        secretName: capi-controllers-webhook-service-cert
+    - name: metrics-cert
+      secret:
+        defaultMode: 420
+        secretName: capi-controllers-metrics-tls
+    - name: kube-api-access-5zjxk
+      projected:
+        defaultMode: 420
+        sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+                - key: ca.crt
+                  path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+          - configMap:
+              items:
+                - key: service-ca.crt
+                  path: service-ca.crt
+              name: openshift-service-ca.crt
+status:
+  conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T08:39:51Z"
+      observedGeneration: 1
+      status: "True"
+      type: PodReadyToStartContainers
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T08:38:46Z"
+      observedGeneration: 1
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:07:31Z"
+      observedGeneration: 1
+      status: "True"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T09:07:31Z"
+      observedGeneration: 1
+      status: "True"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2026-05-29T08:38:46Z"
+      observedGeneration: 1
+      status: "True"
+      type: PodScheduled
+  containerStatuses:
+    - allocatedResources:
+        cpu: 10m
+        memory: 50Mi
+      containerID: cri-o://fake
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imageID: quay.io/openshift-release-dev/ocp-v4.0-fake
+      lastState:
+        terminated:
+          containerID: cri-o://fake
+          exitCode: 1
+          finishedAt: "2026-05-29T08:54:52Z"
+          reason: Error
+          startedAt: "2026-05-29T08:52:52Z"
+      name: capi-controllers
+      ready: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      restartCount: 6
+      started: true
+      state:
+        running:
+          startedAt: "2026-05-29T08:57:33Z"
+      user:
+        linux:
+          gid: 0
+          supplementalGroups:
+            - 0
+          uid: 0
+      volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+          recursiveReadOnly: Disabled
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-cert
+          readOnly: true
+          recursiveReadOnly: Disabled
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-5zjxk
+          readOnly: true
+          recursiveReadOnly: Disabled
+    - allocatedResources:
+        cpu: 10m
+        memory: 50Mi
+      containerID: cri-o://fake
+      image: quay.io/openshift-release-dev/ocp-v4.0-fake
+      imageID: quay.io/openshift-release-dev/ocp-v4.0-fake
+      lastState:
+        terminated:
+          containerID: cri-o://fake
+          exitCode: 1
+          finishedAt: "2026-05-29T09:02:13Z"
+          reason: Error
+          startedAt: "2026-05-29T08:57:33Z"
+      name: machine-api-migration
+      ready: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi
+      restartCount: 7
+      started: true
+      state:
+        running:
+          startedAt: "2026-05-29T09:07:31Z"
+      user:
+        linux:
+          gid: 0
+          supplementalGroups:
+            - 0
+          uid: 0
+      volumeMounts:
+        - mountPath: /tmp/k8s-metrics-server/serving-certs
+          name: metrics-cert
+          readOnly: true
+          recursiveReadOnly: Disabled
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-5zjxk
+          readOnly: true
+          recursiveReadOnly: Disabled
+  hostIP: 10.0.23.213
+  hostIPs:
+    - ip: 10.0.23.213
+  observedGeneration: 1
+  phase: Running
+  podIP: 10.130.0.9
+  podIPs:
+    - ip: 10.130.0.9
+  qosClass: Burstable
+  startTime: "2026-05-29T08:38:46Z"

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controllers-74b8964d87-l854p/capi-controllers/capi-controllers/logs/current.log
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controllers-74b8964d87-l854p/capi-controllers/capi-controllers/logs/current.log
@@ -1,0 +1,1 @@
+capi-controllers-74b8964d87-l854p capi-controllers logs

--- a/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controllers-74b8964d87-l854p/machine-api-migration/machine-api-migration/logs/current.log
+++ b/testdata/must-gather-valid/sample-openshift-release/namespaces/openshift-cluster-api/pods/capi-controllers-74b8964d87-l854p/machine-api-migration/machine-api-migration/logs/current.log
@@ -1,0 +1,1 @@
+capi-controllers-74b8964d87-l854p machine-api-migration logs


### PR DESCRIPTION
## Description

Add support for CAPI resources, such as, `Cluster`, `Machine`, `MachineSet`, `MachineDeployment`, `AWSCluster`, `AWSMachine`, and `AWSMachineTemplate` resources from the `openshift-cluster-api` namespace.

We are adding support to provision machines via CAPI in OCP; thus, it would be nice to see those resources displayed in camgi for debugging.

## AI Usage

I don't really know Rust so Claude helped me a lot here :D

Assisted By: Claude Opus 4.6 <noreply@anthropic.com>

## Sample

Test data was added for a quick preview. Run:

```bash
make html-designer
```
