### PR TITLE
revert docker build file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camgi"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "camgi"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 readme = "README.md"

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14
 
 RUN wget https://sh.rustup.rs -O rustup.sh
 RUN sh ./rustup.sh -y


### PR DESCRIPTION
this is to help ensure that older version of ocp can utilize the camgi binary in ci. if the wrong version is used, this error message can be see in the must-gather output:

```
/tmp/camgi: /lib64/libc.so.6: version `GLIBC_2.30' not found (required by /tmp/camgi)
```